### PR TITLE
Group Settings UI

### DIFF
--- a/quark_bot/src/ai/moderation/dto.rs
+++ b/quark_bot/src/ai/moderation/dto.rs
@@ -25,29 +25,8 @@ pub struct ModerationState {
     pub step: String,
     pub allowed_items: Option<Vec<String>>,
     pub message_id: Option<i64>,
+    #[serde(default)]
+    pub started_by_user_id: Option<i64>,
 }
 
-impl From<(String, Option<Vec<String>>, Option<i64>)> for ModerationState {
-    fn from(value: (String, Option<Vec<String>>, Option<i64>)) -> Self {
-        let (step, allowed_items, message_id) = value;
-
-        Self {
-            step,
-            allowed_items,
-            message_id,
-        }
-    }
-}
-
-impl From<(Vec<String>, Vec<String>, i64, i64)> for ModerationSettings {
-    fn from(value: (Vec<String>, Vec<String>, i64, i64)) -> Self {
-        let (allowed_items, disallowed_items, updated_by_user_id, updated_at_unix_ms) = value;
-
-        Self {
-            allowed_items,
-            disallowed_items,
-            updated_by_user_id,
-            updated_at_unix_ms,
-        }
-    }
-}
+// Implementations intentionally omitted to keep dto.rs data-only

--- a/quark_bot/src/ai/moderation/mod.rs
+++ b/quark_bot/src/ai/moderation/mod.rs
@@ -3,5 +3,9 @@ pub mod handler;
 pub mod moderation_service;
 pub mod overrides;
 
-pub use dto::ModerationOverrides;
+pub use dto::{
+    ModerationOverrides,
+    ModerationSettings,
+    ModerationState,
+};
 pub use moderation_service::ModerationService;

--- a/quark_bot/src/bot/answers.rs
+++ b/quark_bot/src/bot/answers.rs
@@ -4,7 +4,7 @@ use teloxide::{Bot, prelude::*, types::Message};
 
 use super::handler::{
     handle_add_files, handle_chat, handle_help, handle_list_files, handle_login_group,
-    handle_login_user, handle_mod, handle_moderation_rules, handle_new_chat, handle_prices,
+    handle_login_user, handle_mod, handle_new_chat, handle_prices, handle_rules,
 };
 use crate::announcement::handle_announcement;
 use crate::utils;
@@ -140,8 +140,8 @@ pub async fn answers(
         Command::Report => {
             handle_mod(bot, msg, bot_deps.clone()).await?;
         }
-        Command::ModerationRules => {
-            handle_moderation_rules(bot, msg).await?;
+        Command::Rules => {
+            handle_rules(bot, msg, bot_deps.clone()).await?;
         }
 
         Command::PromptExamples => {

--- a/quark_bot/src/bot/handler_tree.rs
+++ b/quark_bot/src/bot/handler_tree.rs
@@ -177,7 +177,7 @@ pub fn handler_tree() -> Handler<'static, Result<()>, DpHandlerDescription> {
                             matches!(
                                 cmd,
                                 Command::G(_) | Command::Groupsettings
-                                    | Command::Report | Command::GroupBalance(_) | Command::GroupWalletAddress | Command::ModerationRules | Command::SchedulePrompt | Command::ListScheduled | Command::SchedulePayment | Command::ListScheduledPayments
+                                    | Command::Report | Command::GroupBalance(_) | Command::GroupWalletAddress | Command::Rules | Command::SchedulePrompt | Command::ListScheduled | Command::SchedulePayment | Command::ListScheduledPayments
                             )
                         })
                         .filter_async(|msg: Message, bot_deps: BotDependencies| async move {

--- a/quark_bot/src/main.rs
+++ b/quark_bot/src/main.rs
@@ -226,8 +226,8 @@ async fn main() {
             "Moderate content (reply to message) and send a report to the admin if content is found to be inappropriate, muting the user in this case.",
         ),
         BotCommand::new(
-            "moderationrules",
-            "Display the moderation rules to avoid getting muted.",
+            "rules",
+            "Show core and custom rules for this group.",
         ),
         BotCommand::new("balance", "Get your balance of a token."),
         BotCommand::new("groupwalletaddress", "Get the group's wallet address."),

--- a/quark_core/src/helpers/bot_commands.rs
+++ b/quark_core/src/helpers/bot_commands.rs
@@ -33,8 +33,8 @@ pub enum Command {
         description = "Moderate content (reply to message) and send a report to the admin if content is found to be inappropriate, muting the user in this case."
     )]
     Report,
-    #[command(description = "Display the moderation rules to avoid getting muted.")]
-    ModerationRules,
+    #[command(description = "Show core and custom rules for this group.")]
+    Rules,
     #[command(description = "Get your wallet address.")]
     WalletAddress,
     #[command(description = "Get your balance of a token.")]


### PR DESCRIPTION
When Group Settings → Rules is clicked:

Show Allow Rules section.

Show Disallow Rules section.

/rules Command

Implement /rules command.

Command should only work inside groups.

Output should include:

Core rules (default, system-defined).

Custom rules (set by group admins).

Custom Rules Handling

Support case where admins add no allow or disallow rules.

Bot should handle gracefully (e.g., display only core rules or a message saying "No custom rules set").